### PR TITLE
Updated README.md to fix the link to the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Project Link: <https://github.com/ThePhoneProject/advanced-android-camera>
 [stars-url]: https://github.com/ThePhoneProject/advanced-android-camera/stargazers
 [issues-shield]: https://img.shields.io/github/issues/ThePhoneProject/advanced-android-camera.svg?style=for-the-badge
 [issues-url]: https://github.com/ThePhoneProject/advanced-android-camera/issues
-[license-shield]: https://img.shields.io/github/license/gThePhoneProject/advanced-android-camera.svg?style=for-the-badge
+[license-shield]: https://img.shields.io/github/license/ThePhoneProject/advanced-android-camera.svg?style=for-the-badge
 [license-url]: https://github.com/ThePhoneProject/advanced-android-camera/blob/main/LICENSE.md
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://uk.linkedin.com/in/josephereeve


### PR DESCRIPTION
Note: the license we're using isn't currently automatically recognised by github.com so the badge is in grey and generic.