### PR TITLE
:construction_worker: Don't create releases as draft

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         tag: v${{ github.run_number }}
         name: "Nightly ${{ github.run_number }}"
-        draft: true
+        draft: false
         prerelease: true
         artifacts: ${{steps.sign_app.outputs.signedFile}}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Main builds should be accessible - draft means that only admins can see them