### PR TITLE
:bug: Only create 2 use-cases at a time (important for low-power devices)

### DIFF
--- a/app/src/main/java/co/stonephone/stonecamera/StoneCameraApp.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/StoneCameraApp.kt
@@ -89,7 +89,7 @@ fun StoneCameraApp(
     LaunchedEffect(previewView, imageCapture) {
         if (previewView != null && imageCapture != null) {
             viewfinderDimensions = calculateImageCoverageRegion(
-                previewView!!, imageCapture
+                previewView, imageCapture
             )
         }
     }


### PR DESCRIPTION
Low-power devices only allow a max of 2 use-cases.
Right now, we never make use of 3 use-cases at once.

We should at some point (part of the plugin), bind all when possible, so we don't have a switching lag on devices that can handle all use-cases.