### PR TITLE
First Stab at I18N

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - '**'  # just for testing this pr itself
 
 jobs:
   generate-translations:
@@ -44,30 +43,18 @@ jobs:
         run: ./gradlew updateStringsXml
 
       - name: Generate Translations
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./gradlew generateTranslations
-
-      - name: Check for changes
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            echo "Changes detected."
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git checkout -b update-translations
-            git add .
-            git commit -m "Update translations"
-          else
-            echo "No changes detected."
-            echo "::set-output name=changes::false"
-          fi
-        id: changes-check
 
       - name: Create Pull Request
         if: steps.changes-check.outputs.changes != 'false'
         uses: peter-evans/create-pull-request@v5
         with:
-          branch: update-translations
-          title: "Update Translations"
-          body: |
-            This PR updates the translations by running `./gradlew updateStringsXml` and `./gradlew generateTranslations`.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Update Translations ${{ github.event.pull_request.number }}"
+          body: "Update Translations ${{ github.event.pull_request.number }}"
+          branch: i18n-${{ github.event.pull_request.number }}
+          base: main
           labels: |
             translations

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,73 @@
+name: Generate Translations
+
+on:
+  push:
+    branches:
+      - main
+      - '**'  # just for testing this pr itself
+
+jobs:
+  generate-translations:
+    name: Update and Generate Translations
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch full history for creating PRs
+
+    # Set up JDK
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+
+      # Cache Gradle dependencies
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Update Strings XML
+        run: ./gradlew updateStringsXml
+
+      - name: Generate Translations
+        run: ./gradlew generateTranslations
+
+      - name: Check for changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Changes detected."
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git checkout -b update-translations
+            git add .
+            git commit -m "Update translations"
+          else
+            echo "No changes detected."
+            echo "::set-output name=changes::false"
+          fi
+        id: changes-check
+
+      - name: Create Pull Request
+        if: steps.changes-check.outputs.changes != 'false'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: update-translations
+          title: "Update Translations"
+          body: |
+            This PR updates the translations by running `./gradlew updateStringsXml` and `./gradlew generateTranslations`.
+          labels: |
+            translations

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+buildSrc/build

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,12 +4,24 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT">
+            <builds>
+              <build path="$PROJECT_DIR$/buildSrc" name="buildSrc">
+                <projects>
+                  <project path="$PROJECT_DIR$/buildSrc" />
+                </projects>
+              </build>
+            </builds>
+          </compositeBuild>
+        </compositeConfiguration>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/buildSrc" />
           </set>
         </option>
         <option name="resolveExternalAnnotations" value="false" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,10 @@
+import org.w3c.dom.Element
+import java.io.FileNotFoundException
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)

--- a/app/src/main/java/co/stonephone/stonecamera/MainActivity.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import co.stonephone.stonecamera.utils.TranslationManager
 
 class MainActivity : ComponentActivity() {
 
@@ -42,6 +43,8 @@ class MainActivity : ComponentActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        TranslationManager.loadTranslationsForLocale(applicationContext)
 
         if (!isChromeOS()) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT

--- a/app/src/main/java/co/stonephone/stonecamera/StoneCameraApp.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/StoneCameraApp.kt
@@ -1,23 +1,15 @@
 // StoneCameraApp.kt
-@file:kotlin.OptIn(ExperimentalMaterial3Api::class)
-
 package co.stonephone.stonecamera
 
 import android.annotation.SuppressLint
 import android.graphics.Rect
-import android.util.Log
 import androidx.annotation.OptIn
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FlipCameraAndroid
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -185,8 +177,8 @@ fun StoneCameraApp(
                     ) {
                         modePlugins.forEach { modePlugin ->
                             val modeLabel = modePlugin.modeLabel!!
-                            Text(text = modeLabel.uppercase(),
-                                color = if (modeLabel == selectedMode) Color(0xFFFFCC00) else Color.White,
+                            Text(text = modeLabel.resolve().uppercase(),
+                                color = if (modeLabel.resolve() == selectedMode.resolve()) Color(0xFFFFCC00) else Color.White,
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.clickable {

--- a/app/src/main/java/co/stonephone/stonecamera/StoneCameraViewModel.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/StoneCameraViewModel.kt
@@ -28,7 +28,10 @@ import co.stonephone.stonecamera.plugins.IPlugin
 import co.stonephone.stonecamera.plugins.PluginSetting
 import co.stonephone.stonecamera.plugins.PluginUseCase
 import co.stonephone.stonecamera.utils.StoneCameraInfo
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
 import co.stonephone.stonecamera.utils.createCameraSelectorForId
+import co.stonephone.stonecamera.utils.i18n
 import co.stonephone.stonecamera.utils.selectCameraForStepZoomLevel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -74,7 +77,8 @@ class StoneCameraViewModel(
     var isPaused by mutableStateOf(false)
         private set
 
-    var selectedMode by mutableStateOf("photo")
+    @Translatable
+    var selectedMode by mutableStateOf("photo".i18n())
         private set
 
     private val _plugins = mutableListOf<IPlugin>()
@@ -189,7 +193,7 @@ class StoneCameraViewModel(
 
         @Suppress("UNCHECKED_CAST")
         return when (defaultValue) {
-            is String -> prefs.getString(settingKey, defaultValue) as? T
+            is TranslatableString -> (prefs.getString(settingKey, defaultValue.resolve())) as? T
             is Float -> prefs.getFloat(settingKey, defaultValue) as? T
             else -> null
         }
@@ -197,8 +201,17 @@ class StoneCameraViewModel(
 
     // Retrieve a setting with automatic recomposition support
     fun <T> getSetting(settingKey: String): T? {
+        val _value = settings[settingKey]
+
+        val value = when (_value) {
+            is TranslatableString -> _value
+            is String -> _value.i18n()
+            is Float -> prefs.getFloat(settingKey, _value)
+            else -> null
+        }
+
         @Suppress("UNCHECKED_CAST")
-        return settings[settingKey] as? T
+        return value as? T
     }
 
     // Update a setting and notify observers
@@ -207,7 +220,7 @@ class StoneCameraViewModel(
 
         when (setting) {
             is PluginSetting.EnumSetting -> {
-                prefs.edit().putString(settingKey, value as String).apply()
+                prefs.edit().putString(settingKey, (value as TranslatableString).raw).apply()
             }
 
             is PluginSetting.ScalarSetting -> {
@@ -262,7 +275,7 @@ class StoneCameraViewModel(
     /**
      * Switch between Photo and Video modes.
      */
-    fun selectMode(mode: String) {
+    fun selectMode(mode: TranslatableString) {
         plugins.forEach {
             it.onModeSelected(this, selectedMode, mode)
         }
@@ -462,7 +475,6 @@ class StoneCameraViewModel(
                         try {
                             // Await all work to finish
                             workList.awaitAll()
-                            Log.d("Analyzer", "All plugins completed successfully")
                         } catch (e: Exception) {
                             Log.e("Analyzer", "Error in one or more plugins", e)
                         } finally {

--- a/app/src/main/java/co/stonephone/stonecamera/StoneCameraViewModel.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/StoneCameraViewModel.kt
@@ -193,7 +193,7 @@ class StoneCameraViewModel(
 
         @Suppress("UNCHECKED_CAST")
         return when (defaultValue) {
-            is TranslatableString -> (prefs.getString(settingKey, defaultValue.resolve())) as? T
+            is TranslatableString -> prefs.getString(settingKey, defaultValue.resolve()) as? T
             is Float -> prefs.getFloat(settingKey, defaultValue) as? T
             else -> null
         }

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/AspectRatio.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/AspectRatio.kt
@@ -17,8 +17,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import co.stonephone.stonecamera.MyApplication
 import co.stonephone.stonecamera.StoneCameraViewModel
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
 import co.stonephone.stonecamera.utils.getLargestMatchingSize
 import co.stonephone.stonecamera.utils.getLargestSensorSize
+import co.stonephone.stonecamera.utils.i18n
 
 class AspectRatioPlugin : IPlugin {
     override val id: String = "aspectRatioPlugin"
@@ -26,8 +29,8 @@ class AspectRatioPlugin : IPlugin {
 
     override fun initialize(viewModel: StoneCameraViewModel) {
         val previewView = viewModel.previewView
-        val aspectRatio = viewModel.getSetting<String>("aspectRatio")
-        if (aspectRatio === "FULL") {
+        val aspectRatio = viewModel.getSetting<TranslatableString>("aspectRatio")
+        if (aspectRatio?.resolve() === "FULL") {
             previewView!!.scaleType = PreviewView.ScaleType.FILL_CENTER
         } else {
             previewView!!.scaleType = PreviewView.ScaleType.FIT_CENTER
@@ -39,10 +42,10 @@ class AspectRatioPlugin : IPlugin {
         imageCapture: ImageCapture.Builder
     ): ImageCapture.Builder {
         // TODO "FULL" aspect ratio isn't cropping on image capture
-        val ratioStr = viewModel.getSetting<String>("aspectRatio") ?: "16:9"
+        val ratioStr = viewModel.getSetting<TranslatableString>("aspectRatio") ?: "16:9".i18n()
         val context = MyApplication.getAppContext()
 
-        val ratioOrNull = parseRatioOrNull(ratioStr)
+        val ratioOrNull = parseRatioOrNull(ratioStr.resolve())
 
         val targetSize = if (ratioOrNull == null) {
             getLargestSensorSize(viewModel.camera!!, context)
@@ -60,10 +63,10 @@ class AspectRatioPlugin : IPlugin {
         viewModel: StoneCameraViewModel,
         preview: Preview.Builder
     ): Preview.Builder {
-        val ratioStr = viewModel.getSetting<String>("aspectRatio") ?: "16:9"
+        val ratioStr = viewModel.getSetting<TranslatableString>("aspectRatio") ?: "16:9".i18n()
 
         val context = MyApplication.getAppContext()
-        val ratioOrNull = parseRatioOrNull(ratioStr)
+        val ratioOrNull = parseRatioOrNull(ratioStr.resolve())
 
         // 1) Figure out the best "preferred size" for this ratio
         val targetSize = if (ratioOrNull == null) {
@@ -151,8 +154,8 @@ class AspectRatioPlugin : IPlugin {
         viewModel: StoneCameraViewModel,
         previewView: PreviewView
     ): PreviewView {
-        val aspectRatio = viewModel.getSetting<String>("aspectRatio")
-        if (aspectRatio == "FULL") {
+        val aspectRatio = viewModel.getSetting<TranslatableString>("aspectRatio")
+        if (aspectRatio?.resolve() == "FULL") {
             previewView.scaleType = PreviewView.ScaleType.FILL_CENTER
         } else {
             previewView.scaleType = PreviewView.ScaleType.FIT_CENTER
@@ -171,11 +174,11 @@ class AspectRatioPlugin : IPlugin {
         listOf(
             PluginSetting.EnumSetting(
                 key = "aspectRatio",
-                defaultValue = "16:9",
-                options = listOf("16:9", "4:3", "FULL"),
+                defaultValue = @Translatable "16:9".i18n(),
+                options = listOf(@Translatable "16:9".i18n(), @Translatable "4:3".i18n(), @Translatable "FULL".i18n()),
                 render = { value, isSelected ->
                     Text(
-                        text = value,
+                        text = value.resolve(),
                         color = if (isSelected) Color(0xFFFFCC00) else Color.White,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
@@ -183,9 +186,9 @@ class AspectRatioPlugin : IPlugin {
                             .padding(8.dp)
                     )
                 },
-                onChange = { viewModel, value ->
+                onChange = { viewModel, _ ->
                     val previewView = viewModel.previewView
-                    if (viewModel.getSetting<String>("aspectRatio") === "FULL") {
+                    if (viewModel.getSetting<TranslatableString>("aspectRatio")?.resolve() === "FULL") {
                         previewView!!.scaleType = PreviewView.ScaleType.FILL_CENTER
                     } else {
                         previewView!!.scaleType = PreviewView.ScaleType.FIT_CENTER
@@ -193,7 +196,7 @@ class AspectRatioPlugin : IPlugin {
                     viewModel.recreateUseCases()
                 },
                 renderLocation = SettingLocation.TOP,
-                label = "Aspect Ratio"
+                label = @Translatable "Aspect Ratio".i18n()
             )
         )
     }

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/Flash.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/Flash.kt
@@ -14,6 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import co.stonephone.stonecamera.StoneCameraViewModel
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
+import co.stonephone.stonecamera.utils.i18n
 
 class FlashPlugin : IPlugin {
     override val id: String = "flashPlugin"
@@ -26,8 +29,8 @@ class FlashPlugin : IPlugin {
     override fun onImageCapture(
         viewModel: StoneCameraViewModel, imageCapture: ImageCapture.Builder
     ): ImageCapture.Builder {
-        val flashMode = viewModel.getSetting<String>("flash") ?: "OFF"
-        val mode = flashModeStringToMode(flashMode)
+        val flashMode = viewModel.getSetting<TranslatableString>("flash") ?: "OFF".i18n()
+        val mode = flashModeStringToMode(flashMode.resolve())
         imageCapture.setFlashMode(mode)
         return imageCapture
     }
@@ -48,26 +51,30 @@ class FlashPlugin : IPlugin {
         listOf(
             PluginSetting.EnumSetting(
                 key = "flash",
-                label = "Flash",
-                defaultValue = "OFF",
-                options = listOf("OFF", "ON", "AUTO"),
+                label = @Translatable "Flash".i18n(),
+                defaultValue = @Translatable "OFF".i18n(),
+                options = listOf(
+                    @Translatable "OFF".i18n(),
+                    @Translatable "ON".i18n(),
+                    @Translatable "AUTO".i18n()
+                ),
                 render = { flashMode, isSelected ->
                     Box(
                         modifier = Modifier.padding(8.dp)
                     ) {
                         Icon(
                             imageVector = when (flashMode) {
-                                "OFF" -> Icons.Default.FlashOff // Replace with your preferred icon
-                                "ON" -> Icons.Default.FlashOn
-                                "AUTO" -> Icons.Default.FlashAuto // You may need to add custom icons for Flash Auto
+                                "OFF".i18n() -> Icons.Default.FlashOff // Replace with your preferred icon
+                                "ON".i18n() -> Icons.Default.FlashOn
+                                "AUTO".i18n() -> Icons.Default.FlashAuto // You may need to add custom icons for Flash Auto
                                 else -> {
                                     Icons.Default.FlashOff
                                 }
                             },
                             contentDescription = when (flashMode) {
-                                "OFF" -> "Flash Off"
-                                "ON" -> "Flash On"
-                                "AUTO" -> "Flash Auto"
+                                "OFF".i18n() -> @Translatable "Flash Off".i18n().resolve()
+                                "ON".i18n() -> @Translatable "Flash On".i18n().resolve()
+                                "AUTO".i18n() -> @Translatable "Flash Auto".i18n().resolve()
                                 else -> {
                                     "Flash"
                                 }

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/IPlugin.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/IPlugin.kt
@@ -8,6 +8,7 @@ import androidx.camera.core.Preview
 import androidx.camera.view.PreviewView
 import androidx.compose.runtime.Composable
 import co.stonephone.stonecamera.StoneCameraViewModel
+import co.stonephone.stonecamera.utils.TranslatableString
 import kotlinx.coroutines.CompletableDeferred
 
 // PluginUseCase Enum ("photo", "analysis", "video")
@@ -27,7 +28,7 @@ interface IPlugin {
         return true
     }
 
-    val modeLabel: String?
+    val modeLabel: TranslatableString?
         get() = null
 
     val renderModeControl: @Composable() (() -> Unit)?
@@ -60,8 +61,8 @@ interface IPlugin {
 
     fun onModeSelected(
         viewModel: StoneCameraViewModel,
-        previousMode: String,
-        nextMode: String
+        previousMode: TranslatableString,
+        nextMode: TranslatableString
     ): Unit {
 
     }
@@ -114,19 +115,19 @@ enum class SettingLocation {
 sealed class PluginSetting(
     val key: String,
     val defaultValue: Any?,
-    val label: String,
+    val label: TranslatableString,
     val onChange: (StoneCameraViewModel, Any?) -> Unit,
     val renderLocation: SettingLocation? = SettingLocation.NONE,
 ) {
 
     class EnumSetting(
         key: String,
-        defaultValue: String,
-        label: String,
+        defaultValue: TranslatableString,
+        label: TranslatableString,
         renderLocation: SettingLocation? = SettingLocation.NONE,
-        val options: List<String>,
-        val render: @Composable (value: String, Boolean) -> Unit,
-        onChange: (StoneCameraViewModel, String) -> Unit
+        val options: List<TranslatableString>,
+        val render: @Composable (value: TranslatableString, Boolean) -> Unit,
+        onChange: (StoneCameraViewModel, TranslatableString?) -> Unit
     ) : PluginSetting(
         key,
         defaultValue,
@@ -139,7 +140,7 @@ sealed class PluginSetting(
         key: String,
         defaultValue: Float,
         renderLocation: SettingLocation? = SettingLocation.NONE,
-        label: String,
+        label: TranslatableString,
         val minValue: Float,
         val maxValue: Float,
         val stepValue: Float? = null,
@@ -155,7 +156,7 @@ sealed class PluginSetting(
     class CustomSetting(
         key: String,
         defaultValue: String,
-        label: String,
+        label: TranslatableString,
         renderLocation: SettingLocation? = SettingLocation.NONE,
         val customRender: @Composable (StoneCameraViewModel, Any?, (Any?) -> Unit) -> Unit, // Render function with a callback for value changes
         onChange: (StoneCameraViewModel, Any?) -> Unit

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/PhotoMode.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/PhotoMode.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import co.stonephone.stonecamera.StoneCameraViewModel
 import co.stonephone.stonecamera.ui.ResponsiveOrientation
+import co.stonephone.stonecamera.utils.i18n
 
 class PhotoModePlugin : IPlugin {
     override val id: String = "photoMode"
@@ -34,7 +35,7 @@ class PhotoModePlugin : IPlugin {
         get() = listOf(PluginUseCase.PHOTO, PluginUseCase.ANALYSIS, PluginUseCase.VIDEO)
 
     override val modeLabel
-        get() = "photo"
+        get() = "photo".i18n()
 
     override val renderModeControl
         get() = @Composable {

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/QRScanner.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/QRScanner.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat.startActivity
 import co.stonephone.stonecamera.MyApplication
 import co.stonephone.stonecamera.StoneCameraViewModel
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
+import co.stonephone.stonecamera.utils.i18n
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.common.InputImage
@@ -62,7 +65,7 @@ class QRScannerPlugin : IPlugin {
     override fun initialize(viewModel: StoneCameraViewModel) {
         value = null
         scanner = BarcodeScanning.getClient()
-        qrScannerEnabled = viewModel.getSetting<String>("qrScannerEnabled").toString()
+        qrScannerEnabled = viewModel.getSetting<TranslatableString>("qrScannerEnabled")?.resolve() ?: "ON"
     }
 
     var width = 0f
@@ -193,12 +196,12 @@ class QRScannerPlugin : IPlugin {
         listOf(
             PluginSetting.EnumSetting(
                 key = "qrScannerEnabled",
-                label = "QR Scanner",
-                defaultValue = "ON",
-                options = listOf("ON", "OFF"),
+                label = @Translatable "QR Scanner".i18n(),
+                defaultValue = @Translatable "ON".i18n(),
+                options = listOf(@Translatable "ON".i18n(), @Translatable "OFF".i18n()),
                 render = { value, isSelected ->
                     Text(
-                        text = value,
+                        text = value.resolve(),
                         color = if (isSelected) Color(0xFFFFCC00) else Color.White,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/SettingsTray.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/SettingsTray.kt
@@ -81,7 +81,7 @@ class SettingsTrayPlugin : IPlugin {
                                         viewModel.getSetting(setting.key) ?: setting.defaultValue
 
                                     Text(
-                                        text = setting.label,
+                                        text = setting.label.resolve(),
                                         color = Color.White,
                                         style = MaterialTheme.typography.bodyLarge,
                                         fontWeight = FontWeight.Bold,
@@ -104,7 +104,9 @@ class SettingsTrayPlugin : IPlugin {
                                                                 setting.key, option
                                                             )
                                                         }) {
-                                                        setting.render(option, option == value)
+                                                        setting.render(
+                                                            option, option == value
+                                                        )
                                                     }
                                                 }
                                             }

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/ShutterFlash.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/ShutterFlash.kt
@@ -1,7 +1,6 @@
 package co.stonephone.stonecamera.plugins
 
 import android.annotation.SuppressLint
-import androidx.camera.core.ImageCapture
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/VideoMode.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/VideoMode.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import co.stonephone.stonecamera.StoneCameraViewModel
 import co.stonephone.stonecamera.ui.ResponsiveOrientation
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
+import co.stonephone.stonecamera.utils.i18n
 
 class VideoModePlugin : IPlugin {
     override val id: String = "videoMode"
@@ -35,8 +38,8 @@ class VideoModePlugin : IPlugin {
 
     override fun onModeSelected(
         viewModel: StoneCameraViewModel,
-        previousMode: String,
-        nextMode: String
+        previousMode: TranslatableString,
+        nextMode: TranslatableString
     ) {
         if (previousMode == modeLabel) {
             viewModel.stopRecording()
@@ -47,7 +50,7 @@ class VideoModePlugin : IPlugin {
         get() = listOf(PluginUseCase.VIDEO, PluginUseCase.PHOTO, PluginUseCase.ANALYSIS)
 
     override val modeLabel
-        get() = "video"
+        get() = @Translatable "video".i18n()
 
     override val renderModeControl
         get() = @Composable {

--- a/app/src/main/java/co/stonephone/stonecamera/plugins/VolumeControls.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/plugins/VolumeControls.kt
@@ -14,6 +14,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import co.stonephone.stonecamera.MyApplication
 import co.stonephone.stonecamera.StoneCameraViewModel
+import co.stonephone.stonecamera.utils.Translatable
+import co.stonephone.stonecamera.utils.TranslatableString
+import co.stonephone.stonecamera.utils.i18n
 
 class VolumeControlsPlugin : IPlugin {
     override val id: String = "volumeControlsPlugin"
@@ -35,9 +38,9 @@ class VolumeControlsPlugin : IPlugin {
         activity?.let {
             it.window.callback = object : android.view.Window.Callback by it.window.callback {
                 override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
-                    val controlModeGet = viewModel.getSetting<String>("volumeControlMode")
+                    val controlModeGet = viewModel.getSetting<TranslatableString>("volumeControlMode")
 
-                    if (isZoomMode || controlModeGet == "Zoom") {
+                    if (isZoomMode || controlModeGet?.resolve() == "Zoom") {
                         clearValueRunnable?.let { handler.removeCallbacks(it) }
 
                         clearValueRunnable = Runnable {
@@ -89,12 +92,16 @@ class VolumeControlsPlugin : IPlugin {
             listOf(
                 PluginSetting.EnumSetting(
                     key = "volumeControlMode",
-                    options = listOf("Zoom", "Capture", "Smart"),
-                    defaultValue = "Smart",
+                    options = listOf(
+                        @Translatable "Zoom".i18n(),
+                        @Translatable "Capture".i18n(),
+                        @Translatable "Smart".i18n()
+                    ),
+                    defaultValue = @Translatable "Smart".i18n(),
                     renderLocation = SettingLocation.NONE,
                     render = { value, isSelected ->
                         Text(
-                            value.uppercase(), 
+                            value.resolve().uppercase(),
                             color = if (isSelected) Color(0xFFFFCC00) else Color.White,
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.Bold,
@@ -105,7 +112,7 @@ class VolumeControlsPlugin : IPlugin {
                     onChange = { viewModel, value ->
                         // NOOP
                     },
-                    label = "Volume Control Mode"
+                    label = @Translatable "Volume Control Mode".i18n()
                 )
             )
         }

--- a/app/src/main/java/co/stonephone/stonecamera/ui/RenderPluginSetting.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/ui/RenderPluginSetting.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import co.stonephone.stonecamera.StoneCameraViewModel
 import co.stonephone.stonecamera.plugins.PluginSetting
+import co.stonephone.stonecamera.utils.TranslatableString
 
 @Composable
 fun RenderPluginSetting(
@@ -16,14 +17,19 @@ fun RenderPluginSetting(
     val value = viewModel.settings[setting.key] ?: setting.defaultValue
     when (setting) {
         is PluginSetting.EnumSetting -> {
+            val _value = when (value) {
+                is TranslatableString -> value
+                else -> TranslatableString(value.toString())
+            }
+
             Box(modifier = Modifier
                 .then(modifier)
                 .clickable {
-                    val currentIndex = setting.options.indexOf(value)
+                    val currentIndex = setting.options.indexOf(_value)
                     val nextIndex = (currentIndex + 1) % setting.options.size
                     viewModel.setSetting(setting.key, setting.options[nextIndex])
                 }) {
-                setting.render(value as String, false)
+                setting.render(_value, false)
             }
         }
 
@@ -37,8 +43,8 @@ fun RenderPluginSetting(
             )
         }
 
-        is PluginSetting.CustomSetting -> setting.customRender(viewModel, value, { value ->
+        is PluginSetting.CustomSetting -> setting.customRender(viewModel, value) { value ->
             viewModel.setSetting(setting.key, value)
-        })
+        }
     }
 }

--- a/app/src/main/java/co/stonephone/stonecamera/utils/TranslatableString.kt
+++ b/app/src/main/java/co/stonephone/stonecamera/utils/TranslatableString.kt
@@ -1,0 +1,117 @@
+package co.stonephone.stonecamera.utils
+
+import android.content.Context
+import android.content.res.Configuration
+import co.stonephone.stonecamera.R
+import java.util.*
+
+/**
+ * A global object to manage translations.
+ */
+object TranslationManager {
+
+    private var translations: Map<String, String> = emptyMap()
+
+    /**
+     * Loads translations for the current device locale.
+     */
+    fun loadTranslationsForLocale(context: Context, locale: Locale = Locale.getDefault()) {
+        val configuration = Configuration(context.resources.configuration)
+        configuration.setLocale(locale)
+        val localizedContext = context.createConfigurationContext(configuration)
+
+        translations = loadStringsFromResources(localizedContext)
+    }
+
+    private fun sanitizeKey(key: String): String {
+        val sanitized = key.replace(Regex("[^a-zA-Z0-9]"), "_")
+        return if (sanitized.firstOrNull()?.isDigit() == true) "_$sanitized" else sanitized
+    }
+
+    /**
+     * Retrieves a translation for a given key, falling back to the key itself if not found.
+     */
+    fun getTranslation(key: String): String {
+        return translations[sanitizeKey(key)] ?: key
+    }
+
+    /**
+     * Loads all string resources from the given context's `strings.xml`.
+     */
+    private fun loadStringsFromResources(context: Context): Map<String, String> {
+        val stringMap = mutableMapOf<String, String>()
+        val resources = context.resources
+        val fields = R.string::class.java.declaredFields
+
+        for (field in fields) {
+            try {
+                val resourceId = field.getInt(null)
+                val value = resources.getString(resourceId)
+                stringMap[field.name] = value
+            } catch (e: Exception) {
+                // Skip any non-string fields
+            }
+        }
+
+        return stringMap
+    }
+}
+
+/**
+ * Represents a translatable string with optional parameters for placeholders.
+ */
+class TranslatableString(
+    val raw: String,
+) {
+
+    /**
+     * Resolves the string using the global TranslationManager.
+     */
+    fun resolve(params: Map<String, String>? = null): String {
+        val template = TranslationManager.getTranslation(raw)
+        return params?.entries?.fold(template) { acc, (placeholder, value) ->
+            acc.replace("{$placeholder}", value)
+        } ?: template
+    }
+
+    /**
+     * Overrides equality to compare based on raw string and parameters.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TranslatableString) return false
+
+        return raw == other.raw
+    }
+
+    /**
+     * Overrides hashCode to ensure consistent hashing based on raw and params.
+     */
+    override fun hashCode(): Int {
+        var result = raw.hashCode()
+        result *= 31
+        return result
+    }
+
+    /**
+     * Returns a readable representation for debugging.
+     */
+    override fun toString(): String {
+        return raw
+    }
+}
+
+/**
+ * Annotation to mark a translatable string.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.EXPRESSION, AnnotationTarget.LOCAL_VARIABLE
+)
+annotation class Translatable
+
+/**
+ * Extension function for creating a translatable string.
+ */
+fun String.i18n() =
+    TranslatableString(this)

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">nombre_de_la_aplicación</string>
+    <string name="Flash">Flash</string>
+    <string name="OFF">APAGADO</string>
+    <string name="ON">ENCENDIDO</string>
+    <string name="AUTO">AUTO</string>
+    <string name="Flash_Off">Flash Apagado</string>
+    <string name="Flash_On">Flash Encendido</string>
+    <string name="Flash_Auto">Flash Auto</string>
+    <string name="_16_9">16:9</string>
+    <string name="_4_3">4:3</string>
+    <string name="FULL">Completo</string>
+    <string name="Aspect_Ratio">Relación de Aspecto</string>
+    <string name="Zoom">Zoom</string>
+    <string name="Capture">Capturar</string>
+    <string name="Smart">Inteligente</string>
+    <string name="Volume_Control_Mode">Modo de Control de Volumen</string>
+    <string name="video">video</string>
+    <string name="QR_Scanner">Escáner QR</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">app_name</string>
+    <string name="Flash">Flash</string>
+    <string name="OFF">DÉSACTIVÉ</string>
+    <string name="ON">ACTIVÉ</string>
+    <string name="AUTO">AUTO</string>
+    <string name="Flash_Off">Flash désactivé</string>
+    <string name="Flash_On">Flash activé</string>
+    <string name="Flash_Auto">Flash auto</string>
+    <string name="_16_9">16:9</string>
+    <string name="_4_3">4:3</string>
+    <string name="FULL">PLEIN</string>
+    <string name="Zoom">Zoom</string>
+    <string name="Capture">Capturer</string>
+    <string name="Smart">Intelligent</string>
+    <string name="Volume_Control_Mode">Mode de contrôle du volume</string>
+    <string name="video">vidéo</string>
+    <string name="QR_Scanner">Lecteur QR</string>
+    <string name="Aspect_Ratio">Ratio d\'aspect</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,23 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <resources>
-    <string name="app_name">StoneCamera</string>
+        
+    <string name="app_name" unused="true">app_name</string>
+
+    <string name="Flash">Flash</string>
+    <string name="OFF">OFF</string>
+    <string name="ON">ON</string>
+    <string name="AUTO">AUTO</string>
+    <string name="Flash_Off">Flash Off</string>
+    <string name="Flash_On">Flash On</string>
+    <string name="Flash_Auto">Flash Auto</string>
+    <string name="_16_9">16:9</string>
+    <string name="_4_3">4:3</string>
+    <string name="FULL">FULL</string>
+    <string name="Aspect_Ratio">Aspect Ratio</string>
+    <string name="Zoom">Zoom</string>
+    <string name="Capture">Capture</string>
+    <string name="Smart">Smart</string>
+    <string name="Volume_Control_Mode">Volume Control Mode</string>
+    <string name="video">video</string>
+    <string name="QR_Scanner">QR Scanner</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     // Versions plugin, etc. as needed
@@ -9,5 +10,15 @@ plugins {
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(layout.buildDirectory.get().asFile)
+}
+
+// Register the task in the build script
+tasks.register<ExtractTranslatableStringsTask>("updateStringsXml") {
+    sourceDir.set(file("app/src/main/java"))
+    stringsFile.set(file("app/src/main/res/values/strings.xml"))
+}
+
+tasks.register<GenerateTranslationsTask>("generateTranslations") {
+    resDir.set(file("app/src/main/res"))
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+//        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+    }
+}
+
+dependencies {
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.15.2")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,13 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+//rootProject.name = "buildSrc"

--- a/buildSrc/src/main/kotlin/GenerateTranslationsTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateTranslationsTask.kt
@@ -1,0 +1,167 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputDirectory
+import java.net.HttpURLConnection
+import java.net.URL
+
+abstract class GenerateTranslationsTask : DefaultTask() {
+
+    @get:InputDirectory
+    abstract val resDir: DirectoryProperty
+
+    private val apiKey: String =
+        System.getenv("OPENAI_API_KEY") ?: error("OPENAI_API_KEY environment variable not set")
+
+    @TaskAction
+    fun generateTranslations() {
+        val languages = listOf("es", "fr")
+        val resDir = resDir.get().asFile
+
+        val baseStringsFile = resDir.resolve("values/strings.xml")
+
+        val translations = mutableMapOf<String, Map<String, String>>()
+        val baseStrings = parseStringsXml(baseStringsFile)
+
+        languages.forEach { lang ->
+            val langStringsFile = resDir.resolve("values-$lang/strings.xml")
+            val langStrings =
+                if (langStringsFile.exists()) parseStringsXml(langStringsFile) else emptyMap()
+
+            val missingKeys = baseStrings.keys - langStrings.keys
+
+            if (missingKeys.isNotEmpty()) {
+                val prompt = buildTranslationPrompt(baseStrings, langStrings, missingKeys, lang)
+                val response = callGptForTranslations(prompt)
+
+                // Parse GPT response
+                val newTranslations = parseGptResponse(baseStrings, response)
+                translations[lang] = newTranslations
+
+                // Update the language file with new translations
+                updateStringsXml(langStringsFile, langStrings + newTranslations)
+            }
+        }
+    }
+
+    private fun parseStringsXml(file: File): Map<String, String> {
+        val doc: Document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+        val elements = doc.getElementsByTagName("string")
+        val strings = mutableMapOf<String, String>()
+
+        for (i in 0 until elements.length) {
+            val element = elements.item(i) as Element
+            val name = element.getAttribute("name")
+            val value = element.textContent
+            strings[name] = value
+        }
+        return strings
+    }
+
+    private fun buildTranslationPrompt(
+        baseStrings: Map<String, String>,
+        existingTranslations: Map<String, String>,
+        missingKeys: Set<String>,
+        language: String
+    ): String {
+        val languageName = when (language) {
+            "es" -> "Spanish"
+            "fr" -> "French"
+            else -> language.capitalize()
+        }
+
+        val existingPrompt =
+            existingTranslations.entries.map { "- ${baseStrings[it.key]} -> ${it.value}" }
+                .joinToString("\n")
+        val requiredPrompt = missingKeys.map { baseStrings[it] }.joinToString("\n") { "- $it" }
+
+        return """Please translate the following words (in the context of an Android camera app UI) from English to $languageName:
+
+Existing Translations:
+$existingPrompt
+
+Required Translations:
+$requiredPrompt
+
+Respond with JSON."""
+    }
+
+    private fun callGptForTranslations(prompt: String): String {
+        val apiUrl = "https://api.openai.com/v1/chat/completions"
+        val requestBody = mapOf(
+            "model" to "gpt-4o",
+            "messages" to listOf(
+                mapOf(
+                    "role" to "system",
+                    "content" to "You are a helpful assistant that translates UI text for Android apps."
+                ),
+                mapOf(
+                    "role" to "user",
+                    "content" to prompt
+                )
+            ),
+            "response_format" to mapOf(
+                "type" to "json_object"
+            )
+        )
+
+        val jsonBody = jacksonObjectMapper().writeValueAsString(requestBody)
+
+        val connection = URL(apiUrl).openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.setRequestProperty("Authorization", "Bearer $apiKey")
+        connection.doOutput = true
+        connection.outputStream.use { it.write(jsonBody.toByteArray()) }
+
+        return connection.inputStream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseGptResponse(
+        baseStrings: Map<String, String>,
+        response: String
+    ): Map<String, String> {
+        val objectMapper = jacksonObjectMapper()
+        val jsonResponse: Map<String, Any> = objectMapper.readValue(response)
+
+        val choices = jsonResponse["choices"] as? List<Map<String, Any>> ?: emptyList()
+        val messageContent =
+            choices.firstOrNull()?.get("message")?.let { (it as Map<*, *>)["content"] } as? String
+                ?: error("Invalid GPT response: $response")
+
+        val res = objectMapper.readValue<Map<String, String>>(messageContent)
+        val invertedBaseStrings = baseStrings.entries.associateBy({ it.value }, { it.key })
+        return res.entries.map { (key, value) -> invertedBaseStrings[key]!! to value }.toMap()
+    }
+
+    private fun updateStringsXml(file: File, strings: Map<String, String>) {
+        val content = buildStringsXmlContent(strings)
+        file.writeText(content)
+    }
+
+    private fun buildStringsXmlContent(strings: Map<String, String>): String {
+        val builder = StringBuilder()
+        builder.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+        builder.append("<resources>\n")
+        strings.forEach { (key, value) ->
+            val escapedValue = escapeXml(value)
+            builder.append("    <string name=\"$key\">$escapedValue</string>\n")
+        }
+        builder.append("</resources>\n")
+        return builder.toString()
+    }
+
+    private fun escapeXml(value: String): String {
+        return value.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "\\")
+            .replace("'", "\\'")
+    }
+}

--- a/buildSrc/src/main/kotlin/UpdateStringsXmlTask.kt
+++ b/buildSrc/src/main/kotlin/UpdateStringsXmlTask.kt
@@ -1,0 +1,113 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+abstract class ExtractTranslatableStringsTask : DefaultTask() {
+
+    init {
+        group = "i18n"
+        description = "Extracts translatable strings and writes them to strings.xml"
+    }
+
+    @get:InputDirectory
+    abstract val sourceDir: DirectoryProperty
+
+    @get:OutputFile
+    abstract val stringsFile: DirectoryProperty
+
+    @TaskAction
+    fun extractStrings() {
+        val sourceDir = sourceDir.get().asFile
+        val stringsXmlFile = stringsFile.get().asFile
+        val translatableStrings = mutableSetOf<String>()
+
+        // Scan files for @Translatable annotations and extract strings
+        sourceDir.walkTopDown()
+            .filter { it.isFile && it.extension in listOf("kt", "java") }
+            .forEach { file ->
+                val regex = Regex("@Translatable\\s*\\\"(.*?)\\\"")
+                file.readLines().forEach { line ->
+                    regex.findAll(line).forEach { match ->
+                        translatableStrings.add(match.groupValues[1])
+                    }
+                }
+            }
+
+        // Load existing strings.xml or create a new one
+        val docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        val document = if (stringsXmlFile.exists()) {
+            docBuilder.parse(stringsXmlFile)
+        } else {
+            docBuilder.newDocument().apply {
+                appendChild(createElement("resources"))
+            }
+        }
+
+        val resources = document.documentElement
+
+        // Collect existing keys and their values
+        val existingStrings = mutableMapOf<String, String>()
+        val existingNodes = mutableListOf<org.w3c.dom.Node>()
+        for (i in 0 until resources.childNodes.length) {
+            val node = resources.childNodes.item(i)
+            if (node.nodeName == "string" && node.hasAttributes()) {
+                val key = node.attributes.getNamedItem("name").nodeValue
+                existingStrings[key] = node.textContent.trim()
+                existingNodes.add(node)
+            }
+        }
+
+        // Update or add new strings
+        translatableStrings.forEach { rawKey ->
+            val sanitizedKey = sanitizeKey(rawKey)
+            if (!existingStrings.containsKey(sanitizedKey)) {
+                val stringNode = document.createElement("string").apply {
+                    setAttribute("name", sanitizedKey)
+                    textContent = rawKey.trim()
+                }
+                resources.appendChild(stringNode)
+            } else {
+                // Mark as used by removing unused="true"
+                val node = existingNodes.firstOrNull { it.attributes.getNamedItem("name").nodeValue == sanitizedKey }
+                try {
+                    node?.attributes?.removeNamedItem("unused")
+                } catch (e: Exception) {
+                    // Ignore if attribute doesn't exist
+                }
+            }
+        }
+
+        // Mark unused strings
+        existingNodes.forEach { node ->
+            val key = node.attributes.getNamedItem("name").nodeValue
+            if (key !in translatableStrings.map { sanitizeKey(it) }) {
+                node.attributes.setNamedItem(document.createAttribute("unused").apply { nodeValue = "true" })
+            }
+        }
+
+        // Write back to strings.xml
+        val transformer = TransformerFactory.newInstance().newTransformer().apply {
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4")
+        }
+        transformer.transform(DOMSource(document), StreamResult(stringsXmlFile))
+
+        println("strings.xml updated with ${translatableStrings.size} translatable strings.")
+    }
+
+    /**
+     * Sanitizes a string to make it a valid XML key.
+     */
+    private fun sanitizeKey(key: String): String {
+        val sanitized = key.replace(Regex("[^a-zA-Z0-9]"), "_")
+        return if (sanitized.firstOrNull()?.isDigit() == true) "_$sanitized" else sanitized
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,6 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
+kotlinStdlib = "1.8.21"
 navigationCompose = "2.8.5"
 material3version = "1.3.1"
 junitJunit = "4.12"
@@ -38,6 +39,7 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose"
 junit-junit = { group = "junit", name = "junit", version.ref = "junitJunit" }
 androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "monitor" }
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinStdlib" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources>
+</resources>


### PR DESCRIPTION
- Implement a custom string internationalisation, because I hate the Android one (perhaps not a good idea, but oh well)
- Create a Gradle task that automatically extracts i18n strings from the code, and adds them to the strings.xml file
- Create a Gradle task that automatically translates english strings to french and spanish (for now) using an LLM
- Add a CI job for this


How to make a string auto-internationalise:
```kotlin
val greeting = "Hello" // normal

val greeting = "Hello".i18n() // magic

// If device locale is french
print(greeting.resolve()) // prints: bonjour

val subString = "Hello, {name}"
print(greeting.resolve(mapOf("name" to "World!"))) // prints: Hello, World!
```